### PR TITLE
Change `rust install` to `rust toolchain install`

### DIFF
--- a/src/rust-2018/rustup-for-managing-rust-versions.md
+++ b/src/rust-2018/rustup-for-managing-rust-versions.md
@@ -17,21 +17,21 @@ version of `rustc` and `cargo`.
 To install a specific Rust version, you can use `rustup install`:
 
 ```console
-$ rustup install 1.30.0
+$ rustup toolchain install 1.30.0
 ```
 
 This works for a specific nightly, as well:
 
 ```console
-$ rustup install nightly-2018-08-01
+$ rustup toolchain install nightly-2018-08-01
 ```
 
 As well as any of our release channels:
 
 ```console
-$ rustup install stable
-$ rustup install beta
-$ rustup install nightly
+$ rustup toochain install stable
+$ rustup toolchain install beta
+$ rustup toolchain install nightly
 ```
 
 ## For updating your installation

--- a/src/rust-2018/rustup-for-managing-rust-versions.md
+++ b/src/rust-2018/rustup-for-managing-rust-versions.md
@@ -29,7 +29,7 @@ $ rustup toolchain install nightly-2018-08-01
 As well as any of our release channels:
 
 ```console
-$ rustup toochain install stable
+$ rustup toolchain install stable
 $ rustup toolchain install beta
 $ rustup toolchain install nightly
 ```


### PR DESCRIPTION
`rustup install` and `rustup uninstall` are going to be deprecated in rustup 1.21.0