### PR TITLE
Clarify the limitation of ? in main and tests

### DIFF
--- a/src/rust-2018/error-handling-and-panics/question-mark-in-main-and-tests.md
+++ b/src/rust-2018/error-handling-and-panics/question-mark-in-main-and-tests.md
@@ -75,7 +75,9 @@ fn main() -> Result<(), std::io::Error> {
 
 In this case, if say the file doesn't exist and there is an `Err(err)` somewhere,
 then `main` will exit with an error code (not `0`) and print out a `Debug`
-representation of `err`.
+representation of `err`. Note that this will always print the `Debug` representation.
+If you would like to, for example, print out the `Display` representation of `err`, 
+you will still have to do what you would in Rust 2015. 
 
 ## More details
 

--- a/src/rust-2018/error-handling-and-panics/question-mark-in-main-and-tests.md
+++ b/src/rust-2018/error-handling-and-panics/question-mark-in-main-and-tests.md
@@ -75,7 +75,7 @@ fn main() -> Result<(), std::io::Error> {
 
 In this case, if say the file doesn't exist and there is an `Err(err)` somewhere,
 then `main` will exit with an error code (not `0`) and print out a `Debug`
-representation of `err`. Note that this will always print the `Debug` representation.
+representation of `err`. Note that this will always print out the `Debug` representation.
 If you would like to, for example, print out the `Display` representation of `err`, 
 you will still have to do what you would in Rust 2015. 
 


### PR DESCRIPTION
I was trying to figure out why my error messages were not printing how I wanted them to (using Display). This page in the edition book is one of the first links that pops up when I googled it, but it wasn't till I saw [this post on the rust forum](https://users.rust-lang.org/t/how-to-customize-the-main-error-message-when-returning-an-error/21903) that I realized there was no way to do this "automatically", so I thought it might be helpful for others to clarify in these docs as well. 