### PR TITLE
Update deprecated GitHub Actions commands.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
       run: |
         mkdir bin
         curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.3.5/mdbook-v0.3.5-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=bin
-        echo "##[add-path]$(pwd)/bin"
+        echo "$(pwd)/bin" >> $GITHUB_PATH
     - name: Report versions
       run: |
         rustup --version


### PR DESCRIPTION
The old method of echoing commands is being deprecated, see https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/.