### PR TITLE
Update notes about static linking and MUSL

### DIFF
--- a/src/rust-2018/platform-and-target-support/musl-support-for-fully-static-binaries.md
+++ b/src/rust-2018/platform-and-target-support/musl-support-for-fully-static-binaries.md
@@ -2,6 +2,9 @@
 
 ![Minimum Rust version: 1.1](https://img.shields.io/badge/Minimum%20Rust%20Version-1.1-brightgreen.svg)
 
+(Note: current Rust (as of 1.48) supports static linking with either glibc or
+MUSL, so you can select whichever libc you need or prefer.)
+
 By default, Rust will statically link all Rust code. However, if you use the
 standard library, it will dynamically link to the system's `libc`
 implementation.


### PR DESCRIPTION
People often use the edition guide as general documentation of
capabilities, not just for Rust 2018. There is extensive information
on the web suggesting that Rust *only* supports static linking with
MUSL. Add a note documenting current capabilities, so that people know
they have a choice of libc implementations even if they need static
linking.