### PR TITLE
Update code generated by `cargo fix --edition`

### DIFF
--- a/src/editions/transitioning-an-existing-project-to-a-new-edition.md
+++ b/src/editions/transitioning-an-existing-project-to-a-new-edition.md
@@ -39,7 +39,7 @@ Let's look at `src/lib.rs` again:
 
 ```rust
 trait Foo {
-    fn foo(&self, _: Box<Foo>);
+    fn foo(&self, _: Box<dyn Foo>);
 }
 ```
 


### PR DESCRIPTION
Update the code generated by `cargo fix --edition` in the given example to include `dyn` in the trait object function parameter.