### PR TITLE
Update musl libc link

### DIFF
--- a/src/rust-2018/platform-and-target-support/musl-support-for-fully-static-binaries.md
+++ b/src/rust-2018/platform-and-target-support/musl-support-for-fully-static-binaries.md
@@ -7,7 +7,7 @@ standard library, it will dynamically link to the system's `libc`
 implementation.
 
 If you'd like a 100% static binary, the [`MUSL
-libc`](https://www.musl-libc.org/) can be used on Linux.
+libc`](https://musl.libc.org/) can be used on Linux.
 
 ## Installing MUSL support
 


### PR DESCRIPTION
musl libc has moved to from https://www.musl-libc.org/ to https://musl.libc.org/