### PR TITLE
Update link for no_std.

### DIFF
--- a/src/rust-2018/module-system/path-clarity.md
+++ b/src/rust-2018/module-system/path-clarity.md
@@ -98,7 +98,7 @@ Some examples of needing to explicitly import sysroot crates are:
 [`test`]: ../../../test/index.html
 [nightly channel]: ../../../book/appendix-07-nightly-rust.html
 [no_core]: https://github.com/rust-lang/rust/issues/29639
-[no_std]: ../../../reference/crates-and-source-files.html#preludes-and-no_std
+[no_std]: ../../../reference/names/preludes.html#the-no_std-attribute
 
 #### Macros
 


### PR DESCRIPTION
There was some reorganization in the reference as part of https://github.com/rust-lang/reference/pull/937.
