### PR TITLE
Add Rust 2021 prelude migration details

### DIFF
--- a/src/rust-2021/prelude.md
+++ b/src/rust-2021/prelude.md
@@ -85,7 +85,7 @@ Some users invoke methods on a `dyn Trait` value where the method name overlaps 
 
 ```rust
 mod submodule {
-  trait MyTrait {
+  pub trait MyTrait {
     // This has the same name as `TryInto::try_into`
     fn try_into(&self) -> Result<u32, ()>;
   }
@@ -114,23 +114,25 @@ ensures that we're calling `try_into` on the `dyn MyTrait` which can only refer 
 Many types define their own inherent methods with the same name as a trait method. For instance, below the struct `MyStruct` implements `from_iter` which shares the same name with the method from the trait `FromIterator` found in the standard library:
 
 ```rust
+use std::iter::IntoIterator;
+
 struct MyStruct {
   data: Vec<u32>
 }
 
 impl MyStruct {
   // This has the same name as `std::iter::FromIterator::from_iter`
-  fn from_iter(iter: impl Iterator<Item = u32>) -> Self {
+  fn from_iter(iter: impl IntoIterator<Item = u32>) -> Self {
     Self {
-      data: iter.collect()
+      data: iter.into_iter().collect()
     }
   }
 }
 
-impl FromIterator<u32> for MyStruct {
+impl std::iter::FromIterator<u32> for MyStruct {
     fn from_iter<I: IntoIterator<Item = u32>>(iter: I) -> Self {
       Self {
-        data: iter.collect()
+        data: iter.into_iter().collect()
       }
     }
 }

--- a/src/rust-2021/prelude.md
+++ b/src/rust-2021/prelude.md
@@ -37,6 +37,12 @@ The tracking issue [can be found here](https://github.com/rust-lang/rust/issues/
 
 As a part of the 2021 edition a migration lint, `rust_2021_prelude_collisions`, has been added in order to aid in automatic migration of Rust 2018 codebases to Rust 2021.
 
+In order to have rustfix migrate your code to be Rust 2021 Edition compatible, run:
+
+```
+cargo fix --edition
+```
+
 ### Implementation Reference
 
 The lint needs to take a couple of factors into account when determining whether or not introducing 2021 Edition to a codebase will cause a name resolution collision (thus breaking the code after changing edition). These factors include:

--- a/src/rust-2021/prelude.md
+++ b/src/rust-2021/prelude.md
@@ -38,7 +38,7 @@ As a part of the 2021 edition a migration lint, `rust_2021_prelude_collisions`, 
 
 In order to have rustfix migrate your code to be Rust 2021 Edition compatible, run:
 
-```
+```ignore
 cargo fix --edition
 ```
 
@@ -69,7 +69,7 @@ A migration is necessary when using "dot method" syntax where the method name is
 in scope. For example, a call like `my_struct.into_iter()` where `into_iter()` used to refer to an inherent method on `MyStruct` but now conflicts with
 the trait method from `IntoIter`. To make these calls unambiguous, fully qualified inherent method syntax must be used:
 
-```rust
+```rust,ignore
 // Before:
 my_struct.into_iter();
 // After:

--- a/src/rust-2021/prelude.md
+++ b/src/rust-2021/prelude.md
@@ -35,7 +35,7 @@ The tracking issue [can be found here](https://github.com/rust-lang/rust/issues/
 
 ## Migration
 
-As a part of the 2021 edition a migration lint, currently `future_prelude_collision`, has been added in order to aid in automatic migration of Rust 2018 codebases to Rust 2021.
+As a part of the 2021 edition a migration lint, `rust_2021_prelude_collisions`, has been added in order to aid in automatic migration of Rust 2018 codebases to Rust 2021.
 
 ### Implementation Reference
 

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1,0 +1,4 @@
+[assign]
+
+[relabel]
+


### PR DESCRIPTION
([rendered](https://github.com/rylev/edition-guide/blob/prelude/src/rust-2021/prelude.md))

Supersedes #248. Fixes #235. 