### PR TITLE
Fix syntax error in code example

### DIFF
--- a/src/rust-2021/prelude.md
+++ b/src/rust-2021/prelude.md
@@ -75,7 +75,7 @@ We can fix this by using fully qualified syntax:
 ```rust,ignore
 fn main() {
   // Now it is clear which trait method we're referring to
-  <Vec<i32> as MyTrait<()>::from_iter(None);
+  <Vec<i32> as MyTrait<()>>::from_iter(None);
 }
 ```
 


### PR DESCRIPTION
It seems that there is a minor syntax error in the code example: a close angle bracket is missing.   I fixed it.