### PR TITLE
Remove `+nightly` for `cargo new`

### DIFF
--- a/src/editions/creating-a-new-project.md
+++ b/src/editions/creating-a-new-project.md
@@ -4,7 +4,7 @@ When you create a new project with Cargo, it will automatically add
 configuration for the latest edition:
 
 ```console
-> cargo +nightly new foo
+> cargo new foo
      Created binary (application) `foo` project
 > cat foo/Cargo.toml
 [package]


### PR DESCRIPTION
`+nightly` is no longer needed now that 2021 has been stabilized.

Closes #275