### PR TITLE
fixes #277: mention rust 1.0 release month and year

### DIFF
--- a/src/editions/index.md
+++ b/src/editions/index.md
@@ -1,6 +1,8 @@
 # What are Editions?
 
-The release of Rust 1.0 established
+The release of Rust 1.0
+([in May 2015](https://blog.rust-lang.org/2015/05/15/Rust-1.0.html))
+established
 ["stability without stagnation"](https://blog.rust-lang.org/2014/10/30/Stability.html)
 as a core Rust deliverable.
 Ever since the 1.0 release,


### PR DESCRIPTION
In the "What are Editions?" section, note that Rust 1.0 was released in May 2015, since it answers a likely question in the mind of the reader considering the preceding commentary referencing that time frame. Writing in Q3 2022, noting the date also helps establish the Rust project's credible commitment to the rule of supporting stable features in perpetuity. It is not something that was just thought up recently -- the project has been adhering to it for more than seven years.