### PR TITLE
use title "The Rust Edition Guide" everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ online](https://doc.rust-lang.org/nightly/edition-guide/).
 
 ## License
 
-The Edition Guide is dual licensed under `MIT`/`Apache2`, just like Rust itself.
-See the `LICENSE-*` files in this repository for more details.
+The Rust Edition Guide is dual licensed under `MIT`/`Apache2`, just like Rust
+itself. See the `LICENSE-*` files in this repository for more details.
 
 ## Building locally
 

--- a/book.toml
+++ b/book.toml
@@ -2,7 +2,7 @@
 authors = ["The Rust Project Developers"]
 multilingual = false
 src = "src"
-title = "The Edition Guide"
+title = "The Rust Edition Guide"
 
 [output.html]
 git-repository-url = "https://github.com/rust-lang/edition-guide"

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -1,4 +1,4 @@
-# The Edition Guide
+# The Rust Edition Guide
 
 [Introduction](introduction.md)
 

--- a/src/editions/index.md
+++ b/src/editions/index.md
@@ -51,11 +51,11 @@ there might be some corner cases where manual changes are still required.
 The tooling tries hard to avoid changes
 to semantics that could affect the correctness or performance of the code.
 
-In addition to tooling, we also maintain this Edition Migration Guide that covers
+In addition to tooling, we also maintain this Rust Edition Guide that covers
 the changes that are part of an edition.
 This guide describes each change and gives pointers to where you can learn more about it.
 It also covers any corner cases or details you should be aware of.
-This guide serves both as an overview of the edition
+This guide serves as an overview of editions,
+as a migration guide for specific editions,
 and as a quick troubleshooting reference
 if you encounter problems with the automated tooling.
-

--- a/src/introduction.md
+++ b/src/introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-Welcome to the Rust Edition Guide! "Editions" are Rust's way of introducing
+Welcome to The Rust Edition Guide! "Editions" are Rust's way of introducing
 changes into the language that would not otherwise be backwards
 compatible.
 


### PR DESCRIPTION
Makes consistent the following references to the title:

    "The Edition Guide"       (book.toml -- document title)
                              (src/SUMMARY.md)
                              (README.md ["License" section text])

    "The Rust Edition Guide"  (README.md [heading])

    "the Rust Edition Guide"  (src/introduction.md)

    "this Edition Migration Guide"  (src/editions/index.md)