### PR TITLE
Update Rust 2018 "Path and module system changes" for Rust 1.72

### DIFF
--- a/src/rust-2018/path-changes.md
+++ b/src/rust-2018/path-changes.md
@@ -272,7 +272,7 @@ enough to have submodules.
 In Rust 2018, paths in `use` declarations and in other code work the same way,
 both in the top-level module and in any submodule. You can use a relative path
 from the current scope, a path starting from an external crate name, or a path
-starting with `crate`, `super`, or `self`.
+starting with `::`, `crate`, `super`, or `self`.
 
 Code that looked like this:
 

--- a/src/rust-2018/path-changes.md
+++ b/src/rust-2018/path-changes.md
@@ -206,6 +206,11 @@ mod submodule {
 }
 ```
 
+If you have a local module or item with the same name as an external crate, a
+path begining with that name will be taken to refer to the local module or
+item. To explicitly refer to the external crate, use the `::name` form.
+
+
 ### No more `mod.rs`
 
 In Rust 2015, if you have a submodule:
@@ -371,9 +376,3 @@ mod submodule {
 
 This makes it easy to move code around in a project, and avoids introducing
 additional complexity to multi-module projects.
-
-If a path is ambiguous, such as if you have an external crate and a local
-module or item with the same name, you'll get an error, and you'll need to
-either rename one of the conflicting names or explicitly disambiguate the path.
-To explicitly disambiguate a path, use `::name` for an external crate name, or
-`self::name` for a local module or item.


### PR DESCRIPTION
Closes #284

Since rust-lang/rust#112086, paths in `use` statements have the same shadowing rules as other paths, at least for the simple cases we're talking about in this guide.

The case of an external crate having the same name as a local module still seems worth mentioning, so I've put it in the "Extern crate paths" section.
