### PR TITLE
Update links and text about rustfix.

### DIFF
--- a/src/editions/advanced-migrations.md
+++ b/src/editions/advanced-migrations.md
@@ -190,7 +190,7 @@ We're now more idiomatic, and we didn't have to fix our code manually!
 [`cargo fix`]: ../../cargo/commands/cargo-fix.html
 [`explicit-outlives-requirements`]:  ../../rustc/lints/listing/allowed-by-default.html#explicit-outlives-requirements
 [`keyword-idents`]: ../../rustc/lints/listing/allowed-by-default.html#keyword-idents
-[`rustfix`]: https://github.com/rust-lang/rustfix
+[`rustfix`]: https://crates.io/crates/rustfix
 [`unused-extern-crates`]: ../../rustc/lints/listing/allowed-by-default.html#unused-extern-crates
 [Cargo features]: ../../cargo/reference/features.html
 [Cargo package]: ../../cargo/reference/manifest.html#the-package-section
@@ -206,5 +206,5 @@ We're now more idiomatic, and we didn't have to fix our code manually!
 [proc macros]: ../../reference/procedural-macros.html
 [Rust Analyzer extension]: https://marketplace.visualstudio.com/items?itemName=matklad.rust-analyzer
 [rustdoc-annotation]: ../../rustdoc/documentation-tests.html#attributes
-[rustfix-examples]: https://github.com/rust-lang/rustfix/tree/master/examples
+[rustfix-examples]: https://github.com/rust-lang/cargo/tree/master/crates/rustfix/examples
 [Visual Studio Code]: https://code.visualstudio.com/

--- a/src/rust-2021/disjoint-capture-in-closures.md
+++ b/src/rust-2021/disjoint-capture-in-closures.md
@@ -32,7 +32,7 @@ Disjoint capture was proposed as part of [RFC 2229](https://github.com/rust-lang
 
 As a part of the 2021 edition a migration lint, `rust_2021_incompatible_closure_captures`, has been added in order to aid in automatic migration of Rust 2018 codebases to Rust 2021.
 
-In order to have `rustfix` migrate your code to be Rust 2021 Edition compatible, run:
+In order to migrate your code to be Rust 2021 Edition compatible, run:
 
 ```sh
 cargo fix --edition

--- a/src/rust-2021/prelude.md
+++ b/src/rust-2021/prelude.md
@@ -36,7 +36,7 @@ The tracking issue [can be found here](https://github.com/rust-lang/rust/issues/
 
 As a part of the 2021 edition a migration lint, `rust_2021_prelude_collisions`, has been added in order to aid in automatic migration of Rust 2018 codebases to Rust 2021.
 
-In order to have `rustfix` migrate your code to be Rust 2021 Edition compatible, run:
+In order to migrate your code to be Rust 2021 Edition compatible, run:
 
 ```sh
 cargo fix --edition
@@ -44,7 +44,7 @@ cargo fix --edition
 
 The lint detects cases where functions or methods are called that have the same name as the methods defined in one of the new prelude traits. In some cases, it may rewrite your calls in various ways to ensure that you continue to call the same function you did before.
 
-If you'd like to migrate your code manually or better understand what `rustfix` is doing, below we've outlined the situations where a migration is needed along with a counter example of when it's not needed.
+If you'd like to migrate your code manually or better understand what `cargo fix` is doing, below we've outlined the situations where a migration is needed along with a counter example of when it's not needed.
 
 ### Migration needed
 

--- a/src/rust-2021/reserving-syntax.md
+++ b/src/rust-2021/reserving-syntax.md
@@ -56,7 +56,7 @@ committed to any of them yet):
 
 As a part of the 2021 edition a migration lint, `rust_2021_prefixes_incompatible_syntax`, has been added in order to aid in automatic migration of Rust 2018 codebases to Rust 2021.
 
-In order to have `rustfix` migrate your code to be Rust 2021 Edition compatible, run:
+In order to migrate your code to be Rust 2021 Edition compatible, run:
 
 ```sh
 cargo fix --edition


### PR DESCRIPTION
Rustfix moved to the cargo repo in https://github.com/rust-lang/cargo/pull/13005.

Additionally, this de-emphasizes "rustfix" as a word, since the library itself is not particularly relevant to the user.
