### PR TITLE
Set up scaffolding for 2024

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -34,3 +34,13 @@
   - [Warnings promoted to errors](rust-2021/warnings-promoted-to-error.md)
   - [Or patterns in macro-rules](rust-2021/or-patterns-macro-rules.md)
   - [C-string literals](rust-2021/c-string-literals.md)
+
+## Rust 2024
+
+- [Rust 2024 🚧](rust-2024/index.md)
+  - [`unsafe_op_in_unsafe_fn` warning](rust-2024/unsafe-op-in-unsafe-fn.md)
+  - [RPIT lifetime capture](rust-2024/rpit-lifetime-capture.md)
+  - [Disallow references to `static mut`](rust-2024/static-mut-reference.md)
+  - [Public/private dependencies](rust-2024/public-private-dependencies.md)
+  - [Cargo: Remove implicit features](rust-2024/cargo-remove-implicit-features.md)
+  - [Rustfmt: Combine all delimited exprs as last argument](rust-2024/rustfmt-overflow-delimited-expr.md)

--- a/src/editions/transitioning-an-existing-project-to-a-new-edition.md
+++ b/src/editions/transitioning-an-existing-project-to-a-new-edition.md
@@ -83,6 +83,19 @@ If new warnings are issued, you may want to consider running `cargo fix` again (
 
 Congrats! Your code is now valid in both Rust 2015 and Rust 2018!
 
+## Migrating to an unstable edition
+
+After an edition is released, there is roughly a three year window before the next edition.
+During that window, new features may be added to the next edition, which will only be available on the [nightly channel].
+If you want to help test those new features before they are stabilized, you can use the nightly channel to try them out.
+
+The steps are roughly similar to the stable channel:
+
+1. Install the most recent nightly: `rustup update nightly`.
+2. Run `cargo +nightly fix --edition`.
+3. Edit `Cargo.toml` and place `cargo-features = ["edition2024"]` at the top (above `[package]`), and change the edition field to say `edition = "2024"`.
+4. Run `cargo +nightly check` to verify it now works in the new edition.
+
 [`cargo fix`]: ../../cargo/commands/cargo-fix.html
 [`cargo test`]: ../../cargo/commands/cargo-test.html
 [Advanced migration strategies]: advanced-migrations.md

--- a/src/editions/transitioning-an-existing-project-to-a-new-edition.md
+++ b/src/editions/transitioning-an-existing-project-to-a-new-edition.md
@@ -96,7 +96,13 @@ The steps are roughly similar to the stable channel:
 3. Edit `Cargo.toml` and place `cargo-features = ["edition2024"]` at the top (above `[package]`), and change the edition field to say `edition = "2024"`.
 4. Run `cargo +nightly check` to verify it now works in the new edition.
 
+> **⚠ Caution**: Features implemented in the next edition may not have automatic migrations implemented with `cargo fix`, and the features themselves may not be finished.
+> When possible, this guide should contain information about which features are implemented
+> on nightly along with more information about their status.
+> A few months before the edition is stabilized, all of the new features should be fully implemented, and the [Rust Blog] will announce a call for testing.
+
 [`cargo fix`]: ../../cargo/commands/cargo-fix.html
 [`cargo test`]: ../../cargo/commands/cargo-test.html
 [Advanced migration strategies]: advanced-migrations.md
 [nightly channel]: ../../book/appendix-07-nightly-rust.html
+[Rust Blog]: https://blog.rust-lang.org/

--- a/src/rust-2024/cargo-remove-implicit-features.md
+++ b/src/rust-2024/cargo-remove-implicit-features.md
@@ -1,0 +1,9 @@
+# Cargo: Remove implicit features
+
+🚧 The 2024 Edition has not yet been released and hence this section is still "under construction".
+
+## Summary
+
+## Details
+
+## Migration

--- a/src/rust-2024/index.md
+++ b/src/rust-2024/index.md
@@ -1,0 +1,21 @@
+# Rust 2024
+
+🚧 The 2024 Edition has not yet been released and hence this section is still "under construction".
+
+| Info | |
+| --- | --- |
+| RFC | [#3501](https://rust-lang.github.io/rfcs/3501-edition-2024.html) |
+| Release version | 1.82.0 (anticipated) |
+
+The Rust 2024 Edition is currently slated for release in Rust 1.82.0.
+Rust 1.82.0 will be in beta for six weeks,
+after which it is released as stable on October 17th.
+
+However, note that Rust is a project run by volunteers.
+We prioritize the personal well-being of everyone working on Rust
+over any deadlines and expectations we might have set.
+This could mean delaying the edition a version if necessary,
+or dropping a feature that turns out to be too difficult or stressful to finish in time.
+
+That said, we are on schedule and many of the difficult problems are already tackled,
+thanks to all the people contributing to Rust 2024! 💛

--- a/src/rust-2024/public-private-dependencies.md
+++ b/src/rust-2024/public-private-dependencies.md
@@ -1,0 +1,9 @@
+# Public/private dependencies
+
+🚧 The 2024 Edition has not yet been released and hence this section is still "under construction".
+
+## Summary
+
+## Details
+
+## Migration

--- a/src/rust-2024/rpit-lifetime-capture.md
+++ b/src/rust-2024/rpit-lifetime-capture.md
@@ -1,0 +1,9 @@
+# RPIT lifetime capture
+
+🚧 The 2024 Edition has not yet been released and hence this section is still "under construction".
+
+## Summary
+
+## Details
+
+## Migration

--- a/src/rust-2024/rustfmt-overflow-delimited-expr.md
+++ b/src/rust-2024/rustfmt-overflow-delimited-expr.md
@@ -1,0 +1,9 @@
+# Rustfmt: Combine all delimited exprs as last argument
+
+🚧 The 2024 Edition has not yet been released and hence this section is still "under construction".
+
+## Summary
+
+## Details
+
+## Migration

--- a/src/rust-2024/static-mut-reference.md
+++ b/src/rust-2024/static-mut-reference.md
@@ -1,0 +1,9 @@
+# Disallow references to static mut
+
+🚧 The 2024 Edition has not yet been released and hence this section is still "under construction".
+
+## Summary
+
+## Details
+
+## Migration

--- a/src/rust-2024/unsafe-op-in-unsafe-fn.md
+++ b/src/rust-2024/unsafe-op-in-unsafe-fn.md
@@ -1,0 +1,9 @@
+# unsafe_op_in_unsafe_fn warning
+
+🚧 The 2024 Edition has not yet been released and hence this section is still "under construction".
+
+## Summary
+
+## Details
+
+## Migration


### PR DESCRIPTION
This sets up a (mostly empty) outline for what has been accepted for the 2024 edition so far.

Closes #290