### PR TITLE
2024: Add note about never_type_fallback_flowing_into_unsafe lint level.

### DIFF
--- a/src/rust-2024/never-type-fallback.md
+++ b/src/rust-2024/never-type-fallback.md
@@ -5,6 +5,9 @@
 ## Summary
 
 - Never type (`!`) to any type ("never-to-any") coercions fall back to never type (`!`) rather than to unit type (`()`).
+- The [`never_type_fallback_flowing_into_unsafe`] lint is now `deny` by default.
+
+[`never_type_fallback_flowing_into_unsafe`]: ../../rustc/lints/listing/warn-by-default.html#never-type-fallback-flowing-into-unsafe
 
 ## Details
 
@@ -53,6 +56,10 @@ In the 2024 edition, the fallback type is now `!`.  (We plan to make this change
 In some cases your code might depend on the fallback type being `()`, so this can cause compilation errors or changes in behavior.
 
 [coercion site]: ../../reference/type-coercions.html#coercion-sites
+
+### `never_type_fallback_flowing_into_unsafe`
+
+The default level of the [`never_type_fallback_flowing_into_unsafe`] lint has been raised from `warn` to `deny` in the 2024 Edition. This lint helps detect a particular interaction with the fallback to `!` and `unsafe` code which may lead to undefined behavior. See the link for a complete description.
 
 ## Migration
 


### PR DESCRIPTION
Updates for the changes from https://github.com/rust-lang/rust/pull/126881. cc @WaffleLapkin