### PR TITLE
Stabilize unsafe extern blocks

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -50,5 +50,5 @@
   - [`gen` keyword](rust-2024/gen-keyword.md)
   - [Macro fragment specifiers](rust-2024/macro-fragment-specifiers.md)
   - [Never type fallback change](rust-2024/never-type-fallback.md)
-  - [`unsafe extern` blocks](rust-2024/unsafe-extern.md)
+  - [Unsafe `extern` blocks](rust-2024/unsafe-extern.md)
   - [Unsafe attributes](rust-2024/unsafe-attributes.md)

--- a/src/rust-2024/unsafe-extern.md
+++ b/src/rust-2024/unsafe-extern.md
@@ -1,4 +1,4 @@
-# `unsafe extern` blocks
+# Unsafe `extern` blocks
 
 🚧 The 2024 Edition has not yet been released and hence this section is still "under construction".
 More information may be found in the tracking issue at <https://github.com/rust-lang/rust/issues/123743>.

--- a/src/rust-2024/unsafe-extern.md
+++ b/src/rust-2024/unsafe-extern.md
@@ -16,8 +16,6 @@ Rust 1.xx <!--TODO--> added the ability in all editions to mark [`extern` blocks
 The syntax for an unsafe `extern` block looks like this:
 
 ```rust
-# #![feature(unsafe_extern_blocks)]
-
 unsafe extern "C" {
     // sqrt (from libm) may be called with any `f64`
     pub safe fn sqrt(x: f64) -> f64;

--- a/src/rust-2024/unsafe-extern.md
+++ b/src/rust-2024/unsafe-extern.md
@@ -11,7 +11,7 @@ More information may be found in the tracking issue at <https://github.com/rust-
 
 ## Details
 
-Rust 1.xx <!--TODO--> added the ability in all editions to mark [`extern` blocks] with the `unsafe` keyword.[^RFC3484] Adding the `unsafe` keyword helps to emphasize that it is the responsibility of the author of the `extern` block to ensure that the signatures are correct. If the signatures are not correct, then it may result in undefined behavior.
+Rust 1.82 added the ability in all editions to mark [`extern` blocks] with the `unsafe` keyword.[^RFC3484] Adding the `unsafe` keyword helps to emphasize that it is the responsibility of the author of the `extern` block to ensure that the signatures are correct. If the signatures are not correct, then it may result in undefined behavior.
 
 The syntax for an unsafe `extern` block looks like this:
 


### PR DESCRIPTION
This goes after this is merged:

- https://github.com/rust-lang/rust/pull/127921

...and CI is going to be happy after it.

r? @traviscross 

Tracking:

- https://github.com/rust-lang/rust/issues/123743