### PR TITLE
Fix deprecated_safe_2024 link

### DIFF
--- a/src/rust-2024/newly-unsafe-functions.md
+++ b/src/rust-2024/newly-unsafe-functions.md
@@ -76,4 +76,4 @@ Alternatively, you can manually enable the lint to find places these functions a
 #![warn(deprecated_safe_2024)]
 ```
 
-[`deprecated_safe_2024`]: ../../rustc/lints/listing/allowed-by-default.html#deprecated-safe
+[`deprecated_safe_2024`]: ../../rustc/lints/listing/allowed-by-default.html#deprecated-safe-2024


### PR DESCRIPTION
I was a little too fast clicking the merge button in #304, and missed a broken link.