### PR TITLE
Fix broken Cargo Book link in cargo-resolver.md

### DIFF
--- a/src/rust-2024/cargo-resolver.md
+++ b/src/rust-2024/cargo-resolver.md
@@ -21,7 +21,7 @@ The setting is only honored for the top-level package of the workspace.
 If you are using a [virtual workspace], you will still need to explicitly set the [`resolver` field]
 in the `[workspace]` definition if you want to opt-in to the new resolver.
 
-For more details on how Rust-version aware dependency resolution works, see [the Cargo book](../..//cargo/reference/resolver.html#rust-version).
+For more details on how Rust-version aware dependency resolution works, see [the Cargo book](../../cargo/reference/resolver.html#rust-version).
 
 [`package.rust-version`]: ../../cargo/reference/rust-version.html
 [`resolver.incompatible-rust-version = "fallback"`]: ../../cargo/reference/config.html#resolverincompatible-rust-versions


### PR DESCRIPTION
Fixed the link to display correctly, as the redundant `/` was causing a Not Found error.