### PR TITLE
Enable triagebot merge-conflicts and shortcuts

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -2,3 +2,9 @@
 
 [relabel]
 
+[shortcut]
+
+[merge-conflicts]
+remove = []
+add = ["S-waiting-on-author"]
+unless = ["S-blocked", "S-waiting-on-review"]


### PR DESCRIPTION
This adds merge conflict notifications added in https://github.com/rust-lang/triagebot/pull/1856