### PR TITLE
Add more triagebot labeling support

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1,6 +1,9 @@
 [assign]
 
 [relabel]
+allow-unauthenticated = [
+    "S-*", "A-*", "Edition-*", "bug", "enhancement", "question",
+]
 
 [shortcut]
 
@@ -8,3 +11,14 @@
 remove = []
 add = ["S-waiting-on-author"]
 unless = ["S-blocked", "S-waiting-on-review"]
+
+[autolabel."S-waiting-on-review"]
+new_pr = true
+
+[review-submitted]
+reviewed_label = "S-waiting-on-author"
+review_labels = ["S-waiting-on-review"]
+
+[review-requested]
+remove_labels = ["S-waiting-on-author"]
+add_labels = ["S-waiting-on-review"]


### PR DESCRIPTION
This adds more labeling support from triagebot:

- Allow users to set labels.
- Automatically label new PRs as S-waiting-on-review.
- Automatically flip labels when reviews are requested or submitted.