### PR TITLE
Re-title "Additions to the prelude"

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -54,7 +54,7 @@
     - [`gen` keyword](rust-2024/gen-keyword.md)
     - [Reserved syntax](rust-2024/reserved-syntax.md)
   - [Standard library](rust-2024/standard-library.md)
-    - [Additions to the prelude](rust-2024/prelude.md)
+    - [Changes to the prelude](rust-2024/prelude.md)
     - [Add `IntoIterator` for `Box<[T]>`](rust-2024/intoiterator-box-slice.md)
     - [Newly unsafe functions](rust-2024/newly-unsafe-functions.md)
   - [Cargo](rust-2024/cargo.md)

--- a/src/rust-2024/prelude.md
+++ b/src/rust-2024/prelude.md
@@ -1,4 +1,4 @@
-# Additions to the prelude
+# Changes to the prelude
 
 ## Summary
 


### PR DESCRIPTION
This re-titles the "Additions to the prelude" chapter for 2024 to "Changes to the prelude" since it also includes *removals*, and thus didn't seem to accurately represent what is changing.