### PR TITLE
2024: Document rustfmt overflow_delimited_expr

### DIFF
--- a/src/rust-2024/rustfmt-overflow-delimited-expr.md
+++ b/src/rust-2024/rustfmt-overflow-delimited-expr.md
@@ -1,10 +1,90 @@
 # Rustfmt: Combine all delimited exprs as last argument
 
-This feature is not yet implemented.
-More information may be found in <https://github.com/rust-lang/rust/pull/114764>.
-
 ## Summary
+
+* Some expressions as the last argument in a list will now overflow instead of indent.
 
 ## Details
 
+When structs, slices, arrays, and block/array-like macros are used as the last argument in an expression list, they are now allowed to overflow (like blocks/closures) instead of being indented on a new line.
+
+```rust,ignore
+// Edition 2021
+
+fn example() {
+    foo(ctx, |param| {
+        action();
+        foo(param)
+    });
+
+    foo(
+        ctx,
+        Bar {
+            x: value,
+            y: value2,
+        },
+    );
+
+    foo(
+        ctx,
+        &[
+            MAROON_TOMATOES,
+            PURPLE_POTATOES,
+            ORGANE_ORANGES,
+            GREEN_PEARS,
+            RED_APPLES,
+        ],
+    );
+
+    foo(
+        ctx,
+        vec![
+            MAROON_TOMATOES,
+            PURPLE_POTATOES,
+            ORGANE_ORANGES,
+            GREEN_PEARS,
+            RED_APPLES,
+        ],
+    );
+}
+```
+
+This now formats as the following in the 2024 style edition:
+
+```rust,ignore
+// Edition 2024
+
+fn example() {
+    foo(ctx, |param| {
+        action();
+        foo(param)
+    });
+
+    foo(ctx, Bar {
+        x: value,
+        y: value2,
+    });
+
+    foo(ctx, &[
+        MAROON_TOMATOES,
+        PURPLE_POTATOES,
+        ORGANE_ORANGES,
+        GREEN_PEARS,
+        RED_APPLES,
+    ]);
+
+    foo(ctx, vec![
+        MAROON_TOMATOES,
+        PURPLE_POTATOES,
+        ORGANE_ORANGES,
+        GREEN_PEARS,
+        RED_APPLES,
+    ]);
+}
+```
+
 ## Migration
+
+The change can be applied automatically by running `cargo fmt` or `rustfmt` with the 2024 Edition. See the [Style edition] chapter for more information on migrating and how style editions work.
+
+[Style edition]: rustfmt-style-edition.md

--- a/src/rust-2024/rustfmt-overflow-delimited-expr.md
+++ b/src/rust-2024/rustfmt-overflow-delimited-expr.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-* Some expressions as the last argument in a list will now overflow instead of indent.
+* Some expressions with multi-line final arguments will now format as a single line, with the final expression overflowing.
 
 ## Details
 


### PR DESCRIPTION
This adds the documentation for `overflow_delimited_expr`.

Tracking issue: https://github.com/rust-lang/rust/issues/123751
Style issue: https://github.com/rust-lang/style-team/issues/149
Style update: https://github.com/rust-lang/rust/pull/114764
Implementation: https://github.com/rust-lang/rustfmt/pull/6260
