### PR TITLE
Add alternatives for static-mut-refs

### DIFF
--- a/src/rust-2024/static-mut-references.md
+++ b/src/rust-2024/static-mut-references.md
@@ -330,7 +330,7 @@ fn set_value(value: i32) {
 }
 ```
 
-The standard library has a nightly-only (unstable) variant of [`UnsafeCell`] called [`SyncUnsafeCell`]. This example above shows a very simplified version of the standard library type, but would be used roughly the same way.
+The standard library has a nightly-only (unstable) variant of [`UnsafeCell`] called [`SyncUnsafeCell`]. This example above shows a very simplified version of the standard library type, but would be used roughly the same way. It can provide even better isolation, so do check out its implementation for more details.
 
 [`UnsafeCell`]: ../../std/cell/struct.UnsafeCell.html
 [`SyncUnsafeCell`]: ../../std/cell/struct.SyncUnsafeCell.html

--- a/src/rust-2024/static-mut-references.md
+++ b/src/rust-2024/static-mut-references.md
@@ -340,7 +340,7 @@ This example includes a fictional `with_interrupts_disabled` function which is t
 
 ### Safe references
 
-In some cases it may be safe to create a reference of a `static mut`. The whole point of the [`static_mut_refs`] lint is that this is very hard to do correctly! However, that's not to say it is *impossible*. If you have a situation where you can guarantee that the aliasing requirements are upheld, such as guaranteeing the static is narrowly scoped (only used in a small module or function), has some internal or external synchronization, accounts for interrupt handlers and reentrancy, etc., then taking a reference may be fine.
+In some cases it may be safe to create a reference of a `static mut`. The whole point of the [`static_mut_refs`] lint is that this is very hard to do correctly! However, that's not to say it is *impossible*. If you have a situation where you can guarantee that the aliasing requirements are upheld, such as guaranteeing the static is narrowly scoped (only used in a small module or function), has some internal or external synchronization, accounts for interrupt handlers and reentrancy, panic safety, drop handlers, etc., then taking a reference may be fine.
 
 There are two approaches you can take for this. You can either allow the [`static_mut_refs`] lint (preferably as narrowly as you can), or convert raw pointers to a reference, as with `&mut *&raw mut MY_STATIC`.
 

--- a/src/rust-2024/static-mut-references.md
+++ b/src/rust-2024/static-mut-references.md
@@ -48,7 +48,9 @@ In situations where no locally-reasoned abstraction is possible and you are ther
 [`addr_of_mut!`]: https://docs.rust-lang.org/core/ptr/macro.addr_of_mut.html
 [raw]: ../../reference/expressions/operator-expr.html#raw-borrow-operators
 
-Note that the following examples are just illustrations and are not intended as full-fledged implementations. There are many details for your specific situation that may require alterations to fit your needs. These are intended to help you see different ways to approach your problem. It is recommended to read the documentation for the specific types in the standard library, the reference on [undefined behavior], the [Rustonomicon], and if you are having questions to reach out on one of the Rust forums such as the [Users Forum].
+Note that the following examples are just illustrations and are not intended as full-fledged implementations. Do not copy these as-is. There are details for your specific situation that may require alterations to fit your needs. These are intended to help you see different ways to approach your problem.
+
+It is recommended to read the documentation for the specific types in the standard library, the reference on [undefined behavior], the [Rustonomicon], and if you are having questions to reach out on one of the Rust forums such as the [Users Forum].
 
 [undefined behavior]: ../../reference/behavior-considered-undefined.html
 [Rustonomicon]: ../../nomicon/index.html

--- a/src/rust-2024/static-mut-references.md
+++ b/src/rust-2024/static-mut-references.md
@@ -332,6 +332,9 @@ fn set_value(value: i32) {
 
 The standard library has a nightly-only (unstable) variant of [`UnsafeCell`] called [`SyncUnsafeCell`]. This example above shows a very simplified version of the standard library type, but would be used roughly the same way. It can provide even better isolation, so do check out its implementation for more details.
 
+This example includes a fictional `with_interrupts_disabled` function which is the type of thing you might see in an embedded environment. For example, the [`critical-section`] crate provides a similar kind of functionality that could be used for an embedded environment.
+
+[`critical-section`]: https://crates.io/crates/critical-section
 [`UnsafeCell`]: ../../std/cell/struct.UnsafeCell.html
 [`SyncUnsafeCell`]: ../../std/cell/struct.SyncUnsafeCell.html
 

--- a/src/rust-2024/static-mut-references.md
+++ b/src/rust-2024/static-mut-references.md
@@ -241,7 +241,7 @@ fn main() {
 }
 ```
 
-This example assumes you can put some default value in the static before it is initialized (the const `default` constructor in this example). If that is not possible, consider using either [`MaybeUninit`], dynamic trait dispatch (with a dummy type that implements a trait), or some other approach to have a default placeholder.
+This example assumes you can put some default value in the static before it is initialized (the const `default` constructor in this example). If that is not possible, consider using either [`MaybeUninit`], or dynamic trait dispatch (with a dummy type that implements a trait), or some other approach to have a default placeholder.
 
 [`MaybeUninit`]: ../../core/mem/union.MaybeUninit.html
 

--- a/src/rust-2024/static-mut-references.md
+++ b/src/rust-2024/static-mut-references.md
@@ -308,7 +308,7 @@ Note that this is largely the same as the [raw pointers](#raw-pointers) example.
 #[repr(transparent)]
 pub struct SyncUnsafeCell<T>(UnsafeCell<T>);
 
-unsafe impl<T> Sync for SyncUnsafeCell<T> {}
+unsafe impl<T: Sync> Sync for SyncUnsafeCell<T> {}
 
 static STATE: SyncUnsafeCell<GlobalState> = SyncUnsafeCell(UnsafeCell::new(GlobalState::new()));
 

--- a/src/rust-2024/static-mut-references.md
+++ b/src/rust-2024/static-mut-references.md
@@ -243,7 +243,11 @@ fn main() {
 
 This example assumes you can put some default value in the static before it is initialized (the const `default` constructor in this example). If that is not possible, consider using either [`MaybeUninit`], or dynamic trait dispatch (with a dummy type that implements a trait), or some other approach to have a default placeholder.
 
+There are community-provided crates that can provide similar one-time initialization, such as the [`static-cell`] crate (which supports targets that do not have atomics by using [`portable-atomic`]).
+
 [`MaybeUninit`]: ../../core/mem/union.MaybeUninit.html
+[`static-cell`]: https://crates.io/crates/static_cell
+[`portable-atomic`]: https://crates.io/crates/portable-atomic
 
 ### Raw pointers
 

--- a/src/rust-2024/static-mut-references.md
+++ b/src/rust-2024/static-mut-references.md
@@ -346,6 +346,10 @@ There are two approaches you can take for this. You can either allow the [`stati
 
 <!-- TODO: Should we prefer one or the other here? -->
 
+#### Short-lived references
+
+If you must create a reference to a `static mut`, then it is recommended to minimize the scope of how long that reference exists. Avoid squirreling the reference away somewhere, or keeping it alive through a large section of code. Keeping it short-lived helps with auditing, and verifying that exclusive access is maintained for the duration. Using pointers should be your default unit, and only convert the pointer to a reference on demand when absolutely required.
+
 ## Migration
 
 There is no automatic migration to fix these references to `static mut`. To avoid undefined behavior you must rewrite your code to use a different approach as recommended in the [Alternatives](#alternatives) section.


### PR DESCRIPTION
This is an attempt to provide more specific examples on how people can safely work around `static-mut-refs`.

Closes https://github.com/rust-lang/rust/issues/123059