### PR TITLE
Correct spelling error in `static-mut-references.md`

### DIFF
--- a/src/rust-2024/static-mut-references.md
+++ b/src/rust-2024/static-mut-references.md
@@ -68,7 +68,7 @@ The [atomic types][atomics] provide integers, pointers, and booleans that can be
 # use std::sync::atomic::Ordering;
 # use std::sync::atomic::AtomicU64;
 
-// Chnage from this:
+// Change from this:
 //   static mut COUNTER: u64 = 0;
 // to this:
 static COUNTER: AtomicU64 = AtomicU64::new(0);


### PR DESCRIPTION
Thanks for all the work that goes into the guide!
I was reading through the beta version of the guide at https://doc.rust-lang.org/beta/edition-guide/rust-2024/static-mut-references.html#atomics and found this spelling error:

The word "Change" in the first example in the atomics section is spelled "Chnage", this PR fixes that very minor thing.