### PR TITLE
Fix hyphenation of “Rust-version–aware”

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -58,7 +58,7 @@
     - [Add `IntoIterator` for `Box<[T]>`](rust-2024/intoiterator-box-slice.md)
     - [Newly unsafe functions](rust-2024/newly-unsafe-functions.md)
   - [Cargo](rust-2024/cargo.md)
-    - [Cargo: Rust version–aware resolver](rust-2024/cargo-resolver.md)
+    - [Cargo: Rust-version–aware resolver](rust-2024/cargo-resolver.md)
     - [Cargo: Table and key name consistency](rust-2024/cargo-table-key-names.md)
     - [Cargo: Reject unused inherited default-features](rust-2024/cargo-inherited-default-features.md)
   - [Rustdoc](rust-2024/rustdoc.md)

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -58,7 +58,7 @@
     - [Add `IntoIterator` for `Box<[T]>`](rust-2024/intoiterator-box-slice.md)
     - [Newly unsafe functions](rust-2024/newly-unsafe-functions.md)
   - [Cargo](rust-2024/cargo.md)
-    - [Cargo: Rust-version aware resolver](rust-2024/cargo-resolver.md)
+    - [Cargo: Rust version–aware resolver](rust-2024/cargo-resolver.md)
     - [Cargo: Table and key name consistency](rust-2024/cargo-table-key-names.md)
     - [Cargo: Reject unused inherited default-features](rust-2024/cargo-inherited-default-features.md)
   - [Rustdoc](rust-2024/rustdoc.md)

--- a/src/rust-2024/cargo-resolver.md
+++ b/src/rust-2024/cargo-resolver.md
@@ -1,8 +1,8 @@
-# Cargo: Rust version–aware resolver
+# Cargo: Rust-version–aware resolver
 
 ## Summary
 
-- `edition = "2024"` implies `resolver = "3"` in `Cargo.toml` which enables a Rust version–aware dependency resolver.
+- `edition = "2024"` implies `resolver = "3"` in `Cargo.toml` which enables a Rust-version–aware dependency resolver.
 
 ## Details
 
@@ -19,7 +19,7 @@ The setting is only honored for the top-level package of the workspace.
 If you are using a [virtual workspace], you will still need to explicitly set the [`resolver` field]
 in the `[workspace]` definition if you want to opt-in to the new resolver.
 
-For more details on how Rust version–aware dependency resolution works, see [the Cargo book](../../cargo/reference/resolver.html#rust-version).
+For more details on how Rust-version–aware dependency resolution works, see [the Cargo book](../../cargo/reference/resolver.html#rust-version).
 
 [`package.rust-version`]: ../../cargo/reference/rust-version.html
 [`resolver.incompatible-rust-version = "fallback"`]: ../../cargo/reference/config.html#resolverincompatible-rust-versions

--- a/src/rust-2024/cargo-resolver.md
+++ b/src/rust-2024/cargo-resolver.md
@@ -1,8 +1,8 @@
-# Cargo: Rust-version aware resolver
+# Cargo: Rust version–aware resolver
 
 ## Summary
 
-- `edition = "2024"` implies `resolver = "3"` in `Cargo.toml` which enables a Rust-version aware dependency resolver.
+- `edition = "2024"` implies `resolver = "3"` in `Cargo.toml` which enables a Rust version–aware dependency resolver.
 
 ## Details
 
@@ -19,7 +19,7 @@ The setting is only honored for the top-level package of the workspace.
 If you are using a [virtual workspace], you will still need to explicitly set the [`resolver` field]
 in the `[workspace]` definition if you want to opt-in to the new resolver.
 
-For more details on how Rust-version aware dependency resolution works, see [the Cargo book](../../cargo/reference/resolver.html#rust-version).
+For more details on how Rust version–aware dependency resolution works, see [the Cargo book](../../cargo/reference/resolver.html#rust-version).
 
 [`package.rust-version`]: ../../cargo/reference/rust-version.html
 [`resolver.incompatible-rust-version = "fallback"`]: ../../cargo/reference/config.html#resolverincompatible-rust-versions


### PR DESCRIPTION
In standard English grammar, the way to hyphenate “Rust version” and “aware” is by using an en dash (https://en.wikipedia.org/wiki/Dash#Attributive_compounds). Inserting a hyphen between “Rust” and “version” isn’t right since the phrase is not usually hyphenated.

An alternative is to write `rust-version`-aware, i.e. specifically referring to the Cargo key. Not sure if that was the intent here.