### PR TITLE
Link to 1.56.0 and 1.85.0 blog posts

### DIFF
--- a/src/rust-2021/index.md
+++ b/src/rust-2021/index.md
@@ -3,7 +3,7 @@
 | Info | |
 | --- | --- |
 | RFC | [#3085](https://github.com/rust-lang/rfcs/pull/3085) |
-| Release version | 1.56.0 |
+| Release version | [1.56.0](https://blog.rust-lang.org/2021/10/21/Rust-1.56.0/) |
 
 The Rust 2021 Edition contains several changes that bring new capabilities and more consistency to the language,
 and opens up room for expansion in the future.

--- a/src/rust-2024/index.md
+++ b/src/rust-2024/index.md
@@ -3,4 +3,4 @@
 | Info | |
 | --- | --- |
 | RFC | [#3501](https://rust-lang.github.io/rfcs/3501-edition-2024.html) |
-| Release version | 1.85.0 |
+| Release version | [1.85.0](https://blog.rust-lang.org/2025/02/20/Rust-1.85.0/) |


### PR DESCRIPTION
This is consistent with 1.31.0 link in Rust 2018 index page.