### PR TITLE
Fix typo of key name `resolver.incompatible-rust-versions`

### DIFF
--- a/src/rust-2024/cargo-resolver.md
+++ b/src/rust-2024/cargo-resolver.md
@@ -8,11 +8,11 @@
 
 Since Rust 1.84.0, Cargo has opt-in support for compatibility with
 [`package.rust-version`] to be considered when selecting dependency versions
-by setting [`resolver.incompatible-rust-version = "fallback"`] in `.cargo/config.toml`.
+by setting [`resolver.incompatible-rust-versions = "fallback"`] in `.cargo/config.toml`.
 
 Starting in Rust 2024, this will be the default.
 That is, writing `edition = "2024"` in `Cargo.toml` will imply `resolver = "3"`
-which will imply [`resolver.incompatible-rust-version = "fallback"`].
+which will imply [`resolver.incompatible-rust-versions = "fallback"`].
 
 The resolver is a global setting for a [workspace], and the setting is ignored in dependencies.
 The setting is only honored for the top-level package of the workspace.
@@ -22,7 +22,7 @@ in the `[workspace]` definition if you want to opt in to the new resolver.
 For more details on how Rust-version aware dependency resolution works, see [the Cargo book](../../cargo/reference/resolver.html#rust-version).
 
 [`package.rust-version`]: ../../cargo/reference/rust-version.html
-[`resolver.incompatible-rust-version = "fallback"`]: ../../cargo/reference/config.html#resolverincompatible-rust-versions
+[`resolver.incompatible-rust-versions = "fallback"`]: ../../cargo/reference/config.html#resolverincompatible-rust-versions
 [workspace]: ../../cargo/reference/workspaces.html
 [virtual workspace]: ../../cargo/reference/workspaces.html#virtual-workspace
 [`resolver` field]: ../../cargo/reference/resolver.html#resolver-versions


### PR DESCRIPTION
In the edition guide it was typo-ed to be missing the trailing `s`.

Disclosure: inconsistency noticed and brought to my attention by GPT-5.4