### PR TITLE
Fix failing test due to invalid_runtime_symbol_definitions

### DIFF
--- a/src/rust-2024/unsafe-attributes.md
+++ b/src/rust-2024/unsafe-attributes.md
@@ -36,6 +36,7 @@ Because the set of symbols across all linked libraries is a global namespace, th
 For example, in previous editions the following crashes on most Unix-like platforms despite containing only safe code:
 
 ```rust,no_run,edition2021
+# #![allow(invalid_runtime_symbol_definitions)]
 fn main() {
     println!("Hello, world!");
 }


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/158522 added a new deny-by-default lint that rejects code that has the wrong definition for well-known functions like malloc. However, this test is explicitly trying to illustrate that, so it needs to reduce the lint level.